### PR TITLE
fix: Adds custom `H256` that derives `serde` macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ thiserror = { workspace = true }
 keccak-hash = { workspace = true }
 parking_lot = { workspace = true }
 hashbrown = { workspace = true }
+fixed-hash = { workspace = true }
 
 [workspace]
 members = [
@@ -29,6 +30,7 @@ members = [
 [workspace.dependencies]
 left-right = "0.11.5"
 keccak-hash = "0.9"
+fixed-hash = "0.7.0"
 log = "0.4.16"
 rlp = "0.5.1"
 rand = "0.8.3"

--- a/jmt/Cargo.toml
+++ b/jmt/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2021"
 
 [lib]
 name = "jmt"
-path = "jmt"
 
 [features]
 default = ["ics23", "std"]

--- a/pmt/Cargo.toml
+++ b/pmt/Cargo.toml
@@ -12,6 +12,7 @@ name = "pmt"
 left-right = { workspace = true }
 hashbrown = { workspace = true }
 keccak-hash = { workspace = true }
+fixed-hash = { workspace = true }
 log = { workspace = true }
 parking_lot = { workspace = true }
 rlp = { workspace = true }

--- a/pmt/Cargo.toml
+++ b/pmt/Cargo.toml
@@ -7,7 +7,6 @@ authors = ["VRRB Labs <info@vrrb.io>"]
 
 [lib]
 name = "pmt"
-path = "pmt"
 
 [dependencies]
 left-right = { workspace = true }

--- a/pmt/src/error.rs
+++ b/pmt/src/error.rs
@@ -1,8 +1,7 @@
-use keccak_hash::H256;
 use rlp::DecoderError;
 use thiserror::Error;
 
-use crate::{nibbles::Nibbles, node::NodeError};
+use crate::{nibbles::Nibbles, node::NodeError, serde_hash::H256};
 
 #[derive(Error, Debug, Clone, Eq, PartialEq)]
 pub enum TrieError {

--- a/pmt/src/inner.rs
+++ b/pmt/src/inner.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use std::{borrow::BorrowMut, fmt::Display};
 
 use hashbrown::{HashMap, HashSet};
-use keccak_hash::{keccak, H256};
 use rlp::{Prototype, Rlp, RlpStream};
 use serde::{Deserialize, Serialize};
 
@@ -17,6 +16,7 @@ use crate::{
     nibbles::Nibbles,
     node::{BranchNode, ExtensionNode, HashNode, Node},
     result::Result,
+    serde_hash::{keccak, H256},
     trie::Trie,
     TrieIterator,
 };
@@ -433,7 +433,7 @@ where
                 ))
             }
             Node::Branch(ref mut branch) => {
-                let mut borrow_branch = branch.borrow_mut();
+                let borrow_branch = branch.borrow_mut();
 
                 if partial.at(0) == 0x10 {
                     borrow_branch.value = Some(value);
@@ -447,7 +447,7 @@ where
                 Ok(Node::Branch(branch.clone()))
             }
             Node::Extension(ext) => {
-                let mut borrow_ext = ext.borrow_mut();
+                let borrow_ext = ext.borrow_mut();
 
                 let prefix = &borrow_ext.prefix;
                 let mut sub_node = borrow_ext.node.clone();
@@ -525,7 +525,7 @@ where
                 Ok((Node::Leaf(leaf.clone()), false))
             }
             Node::Branch(branch) => {
-                let mut borrow_branch = branch.borrow_mut();
+                let borrow_branch = branch.borrow_mut();
 
                 if partial.at(0) == 0x10 {
                     borrow_branch.value = None;

--- a/pmt/src/lib.rs
+++ b/pmt/src/lib.rs
@@ -8,6 +8,7 @@ pub mod trie;
 pub mod trie_iterator;
 
 pub mod common;
+pub mod serde_hash;
 pub use common::*;
 pub use db::*;
 pub use error::*;
@@ -19,7 +20,7 @@ pub use trie_iterator::*;
 pub(crate) mod nibbles;
 pub(crate) mod node;
 
-pub use keccak_hash::H256;
+pub use serde_hash::H256;
 
 #[cfg(test)]
 mod tests {
@@ -28,13 +29,13 @@ mod tests {
         sync::Arc,
     };
 
-    use keccak_hash::{keccak, H256};
     use rand::{distributions::Alphanumeric, seq::SliceRandom, thread_rng, Rng};
 
     use crate::{
         db::{Database, MemoryDB},
         error::TrieError,
         nibbles::Nibbles,
+        serde_hash::{keccak, H256},
     };
     use crate::{InnerTrie, Trie};
 

--- a/pmt/src/node.rs
+++ b/pmt/src/node.rs
@@ -1,8 +1,7 @@
-use keccak_hash::H256;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::{common::BRANCHING_FACTOR, nibbles::Nibbles};
+use crate::{common::BRANCHING_FACTOR, nibbles::Nibbles, serde_hash::H256};
 
 pub type Link = Box<Node>;
 

--- a/pmt/src/serde_hash.rs
+++ b/pmt/src/serde_hash.rs
@@ -1,0 +1,24 @@
+//! An adaptation of the original `keccak` function and `H256` type
+//! that handles the implementation of `serde`.
+
+use fixed_hash::construct_fixed_hash;
+use keccak_hash::write_keccak;
+use serde::{Deserialize, Serialize};
+
+construct_fixed_hash! {
+    /// Fixed-size uninterpreted hash type with 32 bytes (256 bits) size.
+    ///
+    /// This type is an adaptation of `keccak::H256` that accounts for the `serde` derive macros
+    /// that are used within the `pmt` portion of the `patriecia` library.
+    #[cfg_attr(feature = "scale-info", derive(TypeInfo))]
+    #[derive(Serialize, Deserialize)]
+    pub struct H256(32);
+}
+
+/// An adaptation of the `keccak_hash::keccak` function that returns
+/// a [serde_hash::H256].
+pub fn keccak<T: AsRef<[u8]>>(s: T) -> crate::serde_hash::H256 {
+    let mut result = [0u8; 32];
+    write_keccak(s, &mut result);
+    crate::serde_hash::H256(result)
+}

--- a/pmt/src/trie.rs
+++ b/pmt/src/trie.rs
@@ -1,8 +1,7 @@
-use keccak_hash::H256;
-
 use crate::common::{Key, OwnedValue, Value};
 use crate::db::Database;
 use crate::result::Result;
+use crate::serde_hash::H256;
 
 pub trait Trie<D: Database> {
     /// Returns the value for key stored in the trie.


### PR DESCRIPTION
Adds a custom version of the `keccak_hash::H256` type that can implement the derived `serde` macros `Serialize` and `Deserialize`.

Closes #14 